### PR TITLE
First release for X-NUCLEO-6180XA1 library

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,23 @@
+COPYRIGHT(c) 2017 STMicroelectronics
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+  2. Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+  3. Neither the name of STMicroelectronics nor the names of its contributors
+     may be used to endorse or promote products derived from this software
+     without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,38 @@
 # X-NUCLEO-6180XA1
-Arduino library to support the X-NUCLEO-6180XA1 based on VL6180X Time-of-Flight and gesture-detection sensor
+
+Arduino library to support the X-NUCLEO-6180XA1 based on VL6180X proximity sensor, gesture 
+and ambient light sensing (ALS) module. This sensor uses I2C to communicate. An I2C instance 
+is required to access to the sensor. The APIs provide simple distance measure, simple luminosity measure, 
+single swipe gesture detection, directional (left/right) swipe gesture detection and single tap gesture detection.
+
+## Examples
+
+There are 4 examples with the  X-NUCLEO-53L0A1 library.
+* X_NUCLEO_6180XA1_HelloWorld: This example code is to show how to get proximity and luminosity
+  values of the onboard VL6180X sensor
+
+* X_NUCLEO_6180XA1_Gesture_DirSwipe: This example code is to show how to combine the
+  proximity values of the two VL6180X sensor satellites together with the gesture library
+  in order to detect a directional swipe gesture.
+
+* X_NUCLEO_6180XA1_Gesture_Swipe1: This example code is to show how to combine the
+  proximity value of the onboard VL6180X sensor together with the gesture library
+  in order to detect a simple swipe gesture without considering the direction.
+
+* X_NUCLEO_6180XA1_Gesture_Tap1: This example code is to show how to combine the
+  proximity value of the onboard VL6180X sensor together with the gesture
+  library in order to detect a simple tap gesture.
+
+##Dependencies
+
+This package requires the following Arduino libraries:
+* VL6180X: https://github.com/stm32duino/VL6180X
+* Proximity_Gesture: https://github.com/stm32duino/Proximity_Gesture
+
+## Documentation
+
+You can find the source files at  
+https://github.com/stm32duino/X-NUCLEO-6180XA1
+
+The VL6180X datasheet is available at  
+http://www.st.com/content/st_com/en/products/imaging-and-photonics-solutions/proximity-sensors/vl6180x.html

--- a/examples/X_NUCLEO_6180XA1_Gesture_DirSwipe/X_NUCLEO_6180XA1_Gesture_DirSwipe.ino
+++ b/examples/X_NUCLEO_6180XA1_Gesture_DirSwipe/X_NUCLEO_6180XA1_Gesture_DirSwipe.ino
@@ -1,0 +1,171 @@
+/**
+ ******************************************************************************
+ * @file    X_NUCLEO_6180XA1_Gesture_DirSwipe.ino
+ * @author  AST
+ * @version V1.0.0
+ * @date    14-November-2017
+ * @brief   Arduino test application for the STMicrolectronics X-NUCLEO-6180XA1
+ *          proximity sensor expansion board based on FlightSense and gesture library.
+ *          This application makes use of C++ classes obtained from the C
+ *          components' drivers.
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright notice,
+ *      this list of conditions and the following disclaimer in the documentation
+ *      and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************
+ */
+
+
+/* Includes ------------------------------------------------------------------*/
+#include <Arduino.h>
+#include <Wire.h>
+#include <vl6180x_x_nucleo_6180xa1_class.h>
+#include <stmpe1600_class.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <assert.h>
+#include <tof_gestures.h>
+#include <tof_gestures_DIRSWIPE_1.h>
+
+#define DEV_I2C Wire
+#define SerialPort Serial
+
+// Components.
+STMPE1600DigiOut *gpio0_top;
+STMPE1600DigiOut *gpio0_left;
+STMPE1600DigiOut *gpio0_right;
+VL6180X_X_NUCLEO_6180XA1 *sensor_vl6180x_top;
+VL6180X_X_NUCLEO_6180XA1 *sensor_vl6180x_left;
+VL6180X_X_NUCLEO_6180XA1 *sensor_vl6180x_right;
+
+// Gesture structure.
+Gesture_DIRSWIPE_1_Data_t gestureDirSwipeData;
+
+// Range values
+VL6180x_RangeData_t range_left, range_right;
+
+/* Setup ---------------------------------------------------------------------*/
+
+void setup() {
+  int status;
+
+  // Initialize serial for output.
+  SerialPort.begin(115200);
+
+  // Initialize I2C bus.
+  DEV_I2C.begin();
+
+  // Create VL6180X top component.
+  gpio0_top = new STMPE1600DigiOut(&DEV_I2C, GPIO_12);
+  sensor_vl6180x_top = new VL6180X_X_NUCLEO_6180XA1(&DEV_I2C, gpio0_top, 0);
+  
+  // Switch off VL6180X top component.
+  sensor_vl6180x_top->VL6180x_Off();
+  
+  // Create VL6180X left component.
+  gpio0_left = new STMPE1600DigiOut(&DEV_I2C, GPIO_14);
+  sensor_vl6180x_left = new VL6180X_X_NUCLEO_6180XA1(&DEV_I2C, gpio0_left, 0);
+  
+  // Switch off VL6180X left component.
+  sensor_vl6180x_left->VL6180x_Off();
+  
+  // Create VL6180X right component.
+  gpio0_right = new STMPE1600DigiOut(&DEV_I2C, GPIO_15);
+  sensor_vl6180x_right = new VL6180X_X_NUCLEO_6180XA1(&DEV_I2C, gpio0_right, 0);
+  
+  // Switch off VL6180X right component.
+  sensor_vl6180x_right->VL6180x_Off();
+  
+  // Initialize VL6180X left component.
+  status = sensor_vl6180x_left->InitSensor(0x12);
+  if(status)
+  {
+    SerialPort.println("Init sensor_vl6180x_left failed...");
+  }
+  
+  // Initialize VL6180X right component.
+  status = sensor_vl6180x_right->InitSensor(0x13);
+  if(status)
+  {
+    SerialPort.println("Init sensor_vl6180x_right failed...");
+  }
+  
+  // Initialize VL6180X gesture library.
+  tof_gestures_initDIRSWIPE_1(190, 0, 2000, &gestureDirSwipeData);
+}
+
+
+/* Loop ----------------------------------------------------------------------*/
+
+void loop() {
+  int gesture_code;
+  
+  sensor_vl6180x_left->RangeStartSingleShot();
+  sensor_vl6180x_right->RangeStartSingleShot();
+  
+  int left_done = 0;
+  int right_done = 0;
+  
+  do
+  {
+    if(left_done == 0)
+    {
+      int status = sensor_vl6180x_left->RangeGetMeasurementIfReady(&range_left);
+      if(range_left.errorStatus != 18)
+      {
+        left_done = 1;
+      }
+    }
+    
+    if(right_done == 0)
+    {
+      int status = sensor_vl6180x_right->RangeGetMeasurementIfReady(&range_right);
+      if(range_right.errorStatus != 18)
+      {
+        right_done = 1;
+      }
+    }
+  }while(left_done == 0 || right_done == 0);
+  
+  // Launch gesture detection algorithm.
+  gesture_code = tof_gestures_detectDIRSWIPE_1(range_left.range_mm, range_right.range_mm, &gestureDirSwipeData);
+
+  // Check the result of the gesture detection algorithm.
+  switch(gesture_code)
+  {
+    case GESTURES_SWIPE_LEFT_RIGHT:
+      SerialPort.println("From LEFT to RIGHT --->");
+      break;
+    case GESTURES_SWIPE_RIGHT_LEFT:
+      SerialPort.println("From RIGHT to LEFT <---");
+      break;
+    default:
+      // Do nothing
+      break;
+  }
+}

--- a/examples/X_NUCLEO_6180XA1_Gesture_Swipe1/X_NUCLEO_6180XA1_Gesture_Swipe1.ino
+++ b/examples/X_NUCLEO_6180XA1_Gesture_Swipe1/X_NUCLEO_6180XA1_Gesture_Swipe1.ino
@@ -1,0 +1,152 @@
+/**
+ ******************************************************************************
+ * @file    X_NUCLEO_6180XA1_Gesture_Swipe1.ino
+ * @author  AST
+ * @version V1.0.0
+ * @date    14-November-2017
+ * @brief   Arduino test application for the STMicrolectronics X-NUCLEO-6180XA1
+ *          proximity sensor expansion board based on FlightSense and gesture library.
+ *          This application makes use of C++ classes obtained from the C
+ *          components' drivers.
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright notice,
+ *      this list of conditions and the following disclaimer in the documentation
+ *      and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************
+ */
+
+
+/* Includes ------------------------------------------------------------------*/
+#include <Arduino.h>
+#include <Wire.h>
+#include <vl6180x_x_nucleo_6180xa1_class.h>
+#include <stmpe1600_class.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <assert.h>
+#include <tof_gestures.h>
+#include <tof_gestures_SWIPE_1.h>
+
+#define DEV_I2C Wire
+#define SerialPort Serial
+
+// Components.
+STMPE1600DigiOut *gpio0_top;
+STMPE1600DigiOut *gpio0_left;
+STMPE1600DigiOut *gpio0_right;
+VL6180X_X_NUCLEO_6180XA1 *sensor_vl6180x_top;
+VL6180X_X_NUCLEO_6180XA1 *sensor_vl6180x_left;
+VL6180X_X_NUCLEO_6180XA1 *sensor_vl6180x_right;
+
+// Gesture structure.
+Gesture_SWIPE_1_Data_t gestureSwipeData;
+
+// Range value
+VL6180x_RangeData_t range_top;
+
+/* Setup ---------------------------------------------------------------------*/
+
+void setup() {
+  int status;
+
+  // Initialize serial for output.
+  SerialPort.begin(115200);
+
+  // Initialize I2C bus.
+  DEV_I2C.begin();
+  
+  // Create VL6180X top component.
+  gpio0_top = new STMPE1600DigiOut(&DEV_I2C, GPIO_12);
+  sensor_vl6180x_top = new VL6180X_X_NUCLEO_6180XA1(&DEV_I2C, gpio0_top, 0);
+  
+  // Switch off VL6180X top component.
+  sensor_vl6180x_top->VL6180x_Off();
+  
+  // Create (if present) VL6180X left component.
+  gpio0_left = new STMPE1600DigiOut(&DEV_I2C, GPIO_14);
+  sensor_vl6180x_left = new VL6180X_X_NUCLEO_6180XA1(&DEV_I2C, gpio0_left, 0);
+  
+  // Switch off (if present) VL6180X left component.
+  sensor_vl6180x_left->VL6180x_Off();
+  
+  // Create (if present) VL6180X right component.
+  gpio0_right = new STMPE1600DigiOut(&DEV_I2C, GPIO_15);
+  sensor_vl6180x_right = new VL6180X_X_NUCLEO_6180XA1(&DEV_I2C, gpio0_right, 0);
+  
+  // Switch off (if present) VL6180X right component.
+  sensor_vl6180x_right->VL6180x_Off();
+  
+  // Initialize VL6180X top component.
+  status = sensor_vl6180x_top->InitSensor(0x10);
+  if(status)
+  {
+    SerialPort.println("Init sensor_vl6180x_top failed...");
+  }
+  
+  // Initialize VL6180X gesture library.
+  tof_gestures_initSWIPE_1(&gestureSwipeData);
+}
+
+
+/* Loop ----------------------------------------------------------------------*/
+
+void loop() {
+  int gesture_code;
+
+  sensor_vl6180x_top->RangeStartSingleShot();  
+  
+  int top_done = 0;
+  
+  do
+  {
+    if(top_done == 0)
+    {
+      int status = sensor_vl6180x_top->RangeGetMeasurementIfReady(&range_top);
+      if(range_top.errorStatus != 18)
+      {
+        top_done = 1;
+      }
+    }
+  }while(top_done == 0);
+  
+  // Launch gesture detection algorithm.
+  gesture_code = tof_gestures_detectSWIPE_1(range_top.range_mm, &gestureSwipeData);
+
+  // Check the result of the gesture detection algorithm.
+  switch(gesture_code)
+  {
+    case GESTURES_SINGLE_SWIPE:
+      SerialPort.println("GESTURES_SINGLE_SWIPE DETECTED!!!");
+      break;
+    default:
+      // Do nothing
+      break;
+  }
+}
+
+

--- a/examples/X_NUCLEO_6180XA1_Gesture_Tap1/X_NUCLEO_6180XA1_Gesture_Tap1.ino
+++ b/examples/X_NUCLEO_6180XA1_Gesture_Tap1/X_NUCLEO_6180XA1_Gesture_Tap1.ino
@@ -1,0 +1,151 @@
+/**
+ ******************************************************************************
+ * @file    X_NUCLEO_6180XA1_Gesture_Tap1.ino
+ * @author  AST
+ * @version V1.0.0
+ * @date    14-November-2017
+ * @brief   Arduino test application for the STMicrolectronics X-NUCLEO-6180XA1
+ *          proximity sensor expansion board based on FlightSense and gesture library.
+ *          This application makes use of C++ classes obtained from the C
+ *          components' drivers.
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright notice,
+ *      this list of conditions and the following disclaimer in the documentation
+ *      and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************
+ */
+
+
+/* Includes ------------------------------------------------------------------*/
+#include <Arduino.h>
+#include <Wire.h>
+#include <vl6180x_x_nucleo_6180xa1_class.h>
+#include <stmpe1600_class.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <assert.h>
+#include <tof_gestures.h>
+#include <tof_gestures_TAP_1.h>
+
+#define DEV_I2C Wire
+#define SerialPort Serial
+
+// Components.
+STMPE1600DigiOut *gpio0_top;
+STMPE1600DigiOut *gpio0_left;
+STMPE1600DigiOut *gpio0_right;
+VL6180X_X_NUCLEO_6180XA1 *sensor_vl6180x_top;
+VL6180X_X_NUCLEO_6180XA1 *sensor_vl6180x_left;
+VL6180X_X_NUCLEO_6180XA1 *sensor_vl6180x_right;
+
+// Gesture structure.
+Gesture_TAP_1_Data_t gestureTapData;
+
+// Range value
+VL6180x_RangeData_t range_top;
+
+/* Setup ---------------------------------------------------------------------*/
+
+void setup() {
+  int status;
+
+  // Initialize serial for output.
+  SerialPort.begin(115200);
+
+  // Initialize I2C bus.
+  DEV_I2C.begin();
+  
+  // Create VL6180X top component.
+  gpio0_top = new STMPE1600DigiOut(&DEV_I2C, GPIO_12);
+  sensor_vl6180x_top = new VL6180X_X_NUCLEO_6180XA1(&DEV_I2C, gpio0_top, 0);
+  
+  // Switch off VL6180X top component.
+  sensor_vl6180x_top->VL6180x_Off();
+  
+  // Create (if present) VL6180X left component.
+  gpio0_left = new STMPE1600DigiOut(&DEV_I2C, GPIO_14);
+  sensor_vl6180x_left = new VL6180X_X_NUCLEO_6180XA1(&DEV_I2C, gpio0_left, 0);
+  
+  // Switch off (if present) VL6180X left component.
+  sensor_vl6180x_left->VL6180x_Off();
+  
+  // Create VL6180X (if present) right component.
+  gpio0_right = new STMPE1600DigiOut(&DEV_I2C, GPIO_15);
+  sensor_vl6180x_right = new VL6180X_X_NUCLEO_6180XA1(&DEV_I2C, gpio0_right, 0);
+  
+  // Switch off (if present) VL6180X right component.
+  sensor_vl6180x_right->VL6180x_Off();
+  
+  // Initialize VL6180X top component.
+  status = sensor_vl6180x_top->InitSensor(0x10);
+  if(status)
+  {
+    SerialPort.println("Init sensor_vl6180x_top failed...");
+  }
+  
+  // Initialize VL6180X gesture library.
+  tof_gestures_initTAP_1(&gestureTapData);
+}
+
+
+/* Loop ----------------------------------------------------------------------*/
+
+void loop() {
+  int gesture_code;
+
+  sensor_vl6180x_top->RangeStartSingleShot();
+  
+  int top_done = 0;
+  
+  do
+  {
+    if(top_done == 0)
+    {
+      int status = sensor_vl6180x_top->RangeGetMeasurementIfReady(&range_top);
+      if(range_top.errorStatus != 18)
+      {
+        top_done = 1;
+      }
+    }
+  }while(top_done == 0);
+  
+  // Launch gesture detection algorithm.
+  gesture_code = tof_gestures_detectTAP_1(range_top.range_mm, &gestureTapData);
+
+  // Check the result of the gesture detection algorithm.
+  switch(gesture_code)
+  {
+    case GESTURES_SINGLE_TAP:
+      SerialPort.println("GESTURES_SINGLE_TAP DETECTED!!!");
+      break;
+    default:
+      // Do nothing
+      break;
+  }
+}
+

--- a/examples/X_NUCLEO_6180XA1_HelloWorld/X_NUCLEO_6180XA1_HelloWorld.ino
+++ b/examples/X_NUCLEO_6180XA1_HelloWorld/X_NUCLEO_6180XA1_HelloWorld.ino
@@ -1,0 +1,131 @@
+/**
+ ******************************************************************************
+ * @file    X_NUCLEO_6180XA1_HelloWorld.ino
+ * @author  AST
+ * @version V1.0.0
+ * @date    14-November-2017
+ * @brief   Arduino test application for the STMicrolectronics X-NUCLEO-6180XA1
+ *          proximity sensor expansion board based on FlightSense.
+ *          This application makes use of C++ classes obtained from the C
+ *          components' drivers.
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright notice,
+ *      this list of conditions and the following disclaimer in the documentation
+ *      and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************
+ */
+
+
+/* Includes ------------------------------------------------------------------*/
+#include <Arduino.h>
+#include <Wire.h>
+#include <vl6180x_x_nucleo_6180xa1_class.h>
+#include <stmpe1600_class.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <assert.h>
+
+#define DEV_I2C Wire
+#define SerialPort Serial
+
+// Components.
+STMPE1600DigiOut *gpio0_top;
+STMPE1600DigiOut *gpio0_left;
+STMPE1600DigiOut *gpio0_right;
+VL6180X_X_NUCLEO_6180XA1 *sensor_vl6180x_top;
+VL6180X_X_NUCLEO_6180XA1 *sensor_vl6180x_left;
+VL6180X_X_NUCLEO_6180XA1 *sensor_vl6180x_right;
+
+/* Setup ---------------------------------------------------------------------*/
+
+void setup() {
+  int status;
+  // Led.
+  pinMode(13, OUTPUT);
+
+  // Initialize serial for output.
+  SerialPort.begin(115200);
+
+  // Initialize I2C bus.
+  DEV_I2C.begin();
+
+  // Create VL6180X top component.
+  gpio0_top = new STMPE1600DigiOut(&DEV_I2C, GPIO_12);
+  sensor_vl6180x_top = new VL6180X_X_NUCLEO_6180XA1(&DEV_I2C, gpio0_top, 0);
+  
+  // Switch off VL6180X top component.
+  sensor_vl6180x_top->VL6180x_Off();
+  
+  // Create (if present) VL6180X left component.
+  gpio0_left = new STMPE1600DigiOut(&DEV_I2C, GPIO_14);
+  sensor_vl6180x_left = new VL6180X_X_NUCLEO_6180XA1(&DEV_I2C, gpio0_left, 0);
+  
+  // Switch off (if present) VL6180X left component.
+  sensor_vl6180x_left->VL6180x_Off();
+  
+  // Create (if present) VL6180X right component.
+  gpio0_right = new STMPE1600DigiOut(&DEV_I2C, GPIO_15);
+  sensor_vl6180x_right = new VL6180X_X_NUCLEO_6180XA1(&DEV_I2C, gpio0_right, 0);
+  
+  // Switch off (if present) VL6180X right component.
+  sensor_vl6180x_right->VL6180x_Off();
+  
+  // Initialize VL6180X top component.
+  status = sensor_vl6180x_top->InitSensor(0x10);
+  if(status)
+  {
+    SerialPort.println("Init sensor_vl6180x_top failed...");
+  }
+  sensor_vl6180x_top->StartInterleavedMode();
+}
+
+
+/* Loop ----------------------------------------------------------------------*/
+
+void loop() {
+  // Led blinking.
+  digitalWrite(13, HIGH);
+  delay(100);
+  digitalWrite(13, LOW);
+
+  // Read Lux.
+  uint32_t lux;
+  sensor_vl6180x_top->GetLight(&lux);
+  
+  // Read Range.
+  uint32_t range;
+  sensor_vl6180x_top->GetDistance(&range);
+
+  // Output data.
+  char report[64];
+  snprintf(report, sizeof(report), "| Lux[lux]: %ld | Range[mm]: %ld |", lux, range);
+  SerialPort.println(report);
+  
+  delay(200);
+}
+

--- a/keywords.txt
+++ b/keywords.txt
@@ -1,0 +1,18 @@
+#######################################
+# Syntax Coloring Map For x-nucleo-53l0a1
+#######################################
+
+#######################################
+# Datatypes (KEYWORD1)
+#######################################
+
+STMPE1600DigiOut KEYWORD1
+VL53L0X_X_NUCLEO_53L0A1 KEYWORD1
+
+#######################################
+# Methods and Functions (KEYWORD2)
+#######################################
+
+VL53L0X_Off KEYWORD2
+VL53L0X_On KEYWORD2
+write KEYWORD2

--- a/library.properties
+++ b/library.properties
@@ -1,0 +1,9 @@
+name=STM32duino X-NUCLEO-6180XA1
+version=1.0.0
+author=AST
+maintainer=stm32duino
+sentence=Allows controlling the VL6180X sensors on board of X-NUCLEO-6180XA1
+paragraph=This library provides simple measure distance in mm, simple measure luminosity in lux, single swipe gesture detection, directional (left/right) swipe gesture detection and single tap gesture detection.
+category=Device Control
+url=https://github.com/stm32duino/X-NUCLEO-6180XA1
+architectures=stm32

--- a/src/stmpe1600_class.h
+++ b/src/stmpe1600_class.h
@@ -1,0 +1,170 @@
+/**
+ ******************************************************************************
+ * @file    stmpe1600_class.h
+ * @author  AST / EST
+ * @version V0.0.1
+ * @date    14-April-2015
+ * @brief   Header file for component stmpe1600
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2015 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright notice,
+ *      this list of conditions and the following disclaimer in the documentation
+ *      and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software
+ *       without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************
+*/
+#ifndef     __STMPE1600_CLASS
+#define     __STMPE1600_CLASS
+/* Includes ------------------------------------------------------------------*/
+#include <Wire.h>
+
+#define STMPE1600_DEF_DEVICE_ADDRESS  (uint8_t)0x42*2   
+#define STMPE1600_DEF_DIGIOUT_LVL      1
+
+/**  STMPE1600 registr map **/
+#define ChipID_0_7      (uint8_t)0x00
+#define ChipID_8_15     (uint8_t)0x01
+#define VersionId       (uint8_t)0x02
+#define SYS_CTRL        (uint8_t)0x03
+#define IEGPIOR_0_7     (uint8_t)0x08
+#define IEGPIOR_8_15    (uint8_t)0x09
+#define ISGPIOR_0_7	    (uint8_t)0x0A
+#define ISGPIOR_8_15    (uint8_t)0x0B
+#define GPMR_0_7        (uint8_t)0x10
+#define GPMR_8_15       (uint8_t)0x11
+#define GPSR_0_7        (uint8_t)0x12
+#define GPSR_8_15       (uint8_t)0x13
+#define GPDR_0_7        (uint8_t)0x14
+#define GPDR_8_15       (uint8_t)0x15
+#define GPIR_0_7        (uint8_t)0x16
+#define GPIR_8_15	    (uint8_t)0x17
+
+#define SOFT_RESET      (uint8_t)0x80
+
+typedef enum {
+  // GPIO Expander pin names
+  GPIO_0=0,
+  GPIO_1,
+  GPIO_2,
+  GPIO_3,            
+  GPIO_4,
+  GPIO_5,
+  GPIO_6,
+  GPIO_7,            
+  GPIO_8,
+  GPIO_9,
+  GPIO_10,
+  GPIO_11,            
+  GPIO_12,
+  GPIO_13,
+  GPIO_14,
+  GPIO_15,
+  NOT_CON
+} ExpGpioPinName;   
+
+typedef enum {
+    EXP_GPIO_INPUT = 0,
+    EXP_GPIO_OUTPUT,
+    EXP_GPIO_NOT_CONNECTED
+} ExpGpioPinDirection;
+
+/* Classes -------------------------------------------------------------------*/
+/** Class representing a single stmpe1600 GPIO expander output pin
+ */
+class STMPE1600DigiOut {
+	
+ public: 
+    /** Constructor
+     * @param[in] &i2c device I2C to be used for communication
+     * @param[in] outpinname the desired out pin name to be created
+     * @param[in] DevAddr the stmpe1600 I2C device addres (deft STMPE1600_DEF_DEVICE_ADDRESS)
+     * @param[in] lvl the default ot pin level  
+     */ 
+    STMPE1600DigiOut (TwoWire *i2c, ExpGpioPinName outpinname, uint8_t DevAddr=STMPE1600_DEF_DEVICE_ADDRESS, bool lvl=STMPE1600_DEF_DIGIOUT_LVL): dev_i2c(i2c), expdevaddr(DevAddr), exppinname(outpinname) 
+    {
+       uint8_t data[2];				
+       if (exppinname == NOT_CON) return;
+       /* set the exppinname as output */
+       STMPE1600DigiOut_I2CRead(data, expdevaddr, GPDR_0_7, 1);
+       STMPE1600DigiOut_I2CRead(&data[1], expdevaddr, GPDR_8_15, 1);			
+       *(uint16_t*)data = *(uint16_t*)data | (1<<(uint16_t)exppinname);  // set gpio as out 			
+       STMPE1600DigiOut_I2CWrite(data, expdevaddr, GPDR_0_7, 1);
+       STMPE1600DigiOut_I2CWrite(&data[1], expdevaddr, GPDR_8_15, 1);			
+       write(lvl);
+    }   
+
+	/**
+	 * @brief       Write on the out pin
+	 * @param[in]   lvl level to write
+	 * @return      0 on Success
+	 */			
+    void write (int lvl) 
+    {
+       uint8_t data[2];			
+       if (exppinname == NOT_CON) return;			
+       /* set the exppinname state to lvl */
+       STMPE1600DigiOut_I2CRead(data, expdevaddr, GPSR_0_7, 2);
+       *(uint16_t*)data = *(uint16_t*)data & (uint16_t)(~(1<<(uint16_t)exppinname));  // set pin mask 			
+       if (lvl) *(uint16_t*)data = *(uint16_t*)data | (uint16_t)(1<<(uint16_t)exppinname);
+       STMPE1600DigiOut_I2CWrite(data, expdevaddr, GPSR_0_7, 2);
+    }
+		
+ private:
+    TwoWire *dev_i2c; 
+    uint8_t expdevaddr;
+    ExpGpioPinName exppinname;
+
+    int STMPE1600DigiOut_I2CWrite(uint8_t* pBuffer, uint8_t DeviceAddr, uint8_t RegisterAddr, uint16_t NumByteToWrite)
+    {
+      dev_i2c->beginTransmission(((uint8_t)(((DeviceAddr) >> 1) & 0x7F)));
+  
+      dev_i2c->write(RegisterAddr);
+      for (int i = 0 ; i < NumByteToWrite ; i++)
+        dev_i2c->write(pBuffer[i]);
+  
+      dev_i2c->endTransmission(true);
+  
+      return 0;
+    }
+
+    int STMPE1600DigiOut_I2CRead(uint8_t* pBuffer, uint8_t DeviceAddr, uint8_t RegisterAddr, uint16_t NumByteToRead)
+    {
+      dev_i2c->beginTransmission(((uint8_t)(((DeviceAddr) >> 1) & 0x7F)));
+      dev_i2c->write(RegisterAddr);
+      dev_i2c->endTransmission(false);
+  
+      dev_i2c->requestFrom(((uint8_t)(((DeviceAddr) >> 1) & 0x7F)), (byte) NumByteToRead);
+
+      int i=0;
+      while (dev_i2c->available())
+      {
+        pBuffer[i] = dev_i2c->read();
+        i++;
+      }
+  
+      return 0;
+    }
+};
+
+#endif // __STMPE1600_CLASS

--- a/src/vl6180x_x_nucleo_6180xa1_class.h
+++ b/src/vl6180x_x_nucleo_6180xa1_class.h
@@ -1,0 +1,101 @@
+/**
+ ******************************************************************************
+ * @file    vl6180x_x_nucleo_6180xa1_class.h
+ * @author  AST / EST
+ * @version V0.0.1
+ * @date    14-November-2017
+ * @brief   Header file for component VL6180X
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright notice,
+ *      this list of conditions and the following disclaimer in the documentation
+ *      and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software
+ *       without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************
+*/
+
+#ifndef __VL6180X_X_NUCLEO_6180XA1_CLASS_H
+#define __VL6180X_X_NUCLEO_6180XA1_CLASS_H
+
+
+/* Includes ------------------------------------------------------------------*/
+#include "Arduino.h"
+#include "vl6180x_class.h"
+#include "stmpe1600_class.h"
+
+
+/* Classes -------------------------------------------------------------------*/
+/** Class representing a VL6180X sensor component
+ */
+class VL6180X_X_NUCLEO_6180XA1 : public VL6180X
+{
+ public:
+    /** Constructor (STMPE1600DigiOut)
+     * @param[in] i2c device I2C to be used for communication
+     * @param[in] &pin Gpio Expander STMPE1600DigiOut pin to be used as component GPIO_0 CE
+     * @param[in] pin_gpio1 pin Mbed InterruptIn PinName to be used as component GPIO_1 INT
+     * @param[in] device address, 0x29 by default  
+     */		
+    VL6180X_X_NUCLEO_6180XA1(TwoWire *i2c, STMPE1600DigiOut *pin, int pin_gpio1, uint8_t DevAddr=VL6180x_DEFAULT_DEVICE_ADDRESS) : VL6180X(i2c, -1, pin_gpio1, DevAddr)
+    {
+       expgpio0 = pin;
+    }  	 
+    
+   /** Destructor
+    */
+    virtual ~VL6180X_X_NUCLEO_6180XA1(){}     
+    /* warning: VL6180X_X_NUCLEO_6180XA1 class inherits from GenericSensor, RangeSensor and LightSensor, that haven`t a destructor.
+       The warning should request to introduce a virtual destructor to make sure to delete the object */
+
+	/*** Interface Methods ***/	
+	/*** High level API ***/		
+	/**
+	 * @brief       PowerOn the sensor
+	 * @return      void
+	 */		
+    /* turns on the sensor */		 
+    void VL6180x_On(void)
+    { 
+       expgpio0->write(1);    
+    } 
+
+	/**
+	 * @brief       PowerOff the sensor
+	 * @return      void
+	 */		
+    /* turns off the sensor */
+    void VL6180x_Off(void) 
+    { 
+       expgpio0->write(0);   
+    }
+	
+ protected:		
+    /* GPIO expander */
+    STMPE1600DigiOut *expgpio0;  
+};
+
+
+#endif /* __VL6180X_X_NUCLEO_6180XA1_CLASS_H */
+
+


### PR DESCRIPTION
This package supports the X-NUCLEO-6180XA1 shield. The main class derives from VL6180X class adding also a basic support to the gpio expander. The display management is not implemented yet.