### PR TITLE
Remove leading space from keywords.txt identifier

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,13 +6,13 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-STMPE1600DigiOut KEYWORD1
-VL53L0X_X_NUCLEO_53L0A1 KEYWORD1
+STMPE1600DigiOut	KEYWORD1
+VL53L0X_X_NUCLEO_53L0A1	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-VL53L0X_Off KEYWORD2
-VL53L0X_On KEYWORD2
-write KEYWORD2
+VL53L0X_Off	KEYWORD2
+VL53L0X_On	KEYWORD2
+write	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords